### PR TITLE
es module

### DIFF
--- a/packages/hardhat/api/index.js
+++ b/packages/hardhat/api/index.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 const ethers = require('ethers');
 require('dotenv').config({ path: './env' });
 
-module.exports = async function getFirstTransaction (address) {
+export default async function getFirstTransaction (address) {
     console.time()
     console.log(process.env.MY_API_KEY);
     

--- a/packages/react-app/src/api/index.js
+++ b/packages/react-app/src/api/index.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 const ethers = require('ethers');
 require('dotenv').config({ path: './env' });
 
-module.exports = async function getFirstTransaction (address) {
+export default async function getFirstTransaction (address) {
     console.time()
     console.log(process.env.MY_API_KEY);
     


### PR DESCRIPTION
We need to use ES Module syntax instead of CommonJS for exporting functions outside the module file.